### PR TITLE
Fix null upper bound crash in hist_objects_refresh for all-PK tables

### DIFF
--- a/pghist_init.sql
+++ b/pghist_init.sql
@@ -567,7 +567,7 @@ begin
     end if; 
   end loop; 
   select array_agg(col),array_agg(pghist.hist_ident('',col,'_old')) into v_columns_value,v_columns_value_old from unnest(v_columns_name) col where not col = any(v_columns_immutable); 
-  for v_i in 1..array_length(v_columns_name,1) loop
+  for v_i in 1..coalesce(array_length(v_columns_name,1), 0) loop
     v_expression := pghist.hist_expression_value_desc_current(v_schema, v_table_name, v_columns_name[v_i]);
     if v_expression is not null then
       v_sql_part := ' execute '||quote_literal('select ('||v_expression||')')||' into v_change.value_';
@@ -721,7 +721,7 @@ begin
     '      v_change.value_old := null; v_change.value_old_desc := null;'||v_newline||
     '      '||v_row_desc_expr||v_newline||
     '      if hist_columns_insert then'||v_newline;   
-  for v_i in 1..array_length(v_columns_name,1) loop
+  for v_i in 1..coalesce(array_length(v_columns_name,1), 0) loop
     v_col := v_columns_name[v_i];
     if v_col=any(v_columns_immutable) then 
       v_sql := v_sql||'        if hist_columns_immutable then'||v_newline;
@@ -765,7 +765,7 @@ begin
     '      v_change.value_new := null; v_change.value_new_desc := null;'||v_newline||
     '      '||v_sql_hist_to_row||v_newline||
     '      '||v_row_desc_expr||v_newline;
-  for v_i in 1..array_length(v_columns_name,1) loop
+  for v_i in 1..coalesce(array_length(v_columns_name,1), 0) loop
     v_col := v_columns_name[v_i];
     if v_col=any(v_columns_immutable) then 
       v_sql := v_sql||'      if hist_columns_immutable then'||v_newline;


### PR DESCRIPTION
Fix: support tables where all columns are part of the primary key (junction tables)

  Problem

  hist_enable crashed with the following error when called on tables where all columns belong to the primary key (e.g. many-to-many junction tables like a_id, b_id with no additional columns):

  ERROR: upper bound of FOR loop cannot be null
  CONTEXT: PL/pgSQL function pghist.hist_objects_refresh(name,name), line 133

  Root cause

  In hist_objects_refresh, the variable v_columns_name holds the list of non-PK (mutable) columns — columns that can actually change and need to be tracked. For junction tables, every column is part of the primary key, so
  after excluding immutable columns, v_columns_name ends up as NULL.

  The loop then evaluates as:

  FOR v_i IN 1..array_length(NULL, 1) LOOP  -- array_length returns NULL
  -- equivalent to: FOR v_i IN 1..NULL LOOP  -- runtime error

  PostgreSQL does not allow NULL as the upper bound of an integer FOR loop.

  Fix

  Wrap array_length with coalesce to fall back to 0 when the array is NULL:

  FOR v_i IN 1..coalesce(array_length(v_columns_name, 1), 0) LOOP

  In PL/pgSQL, FOR i IN 1..0 is a valid no-op — the loop body is simply skipped. This is exactly the correct behavior: there are no mutable columns to process, so nothing should happen.

  Impact

  This fix has no effect on history correctness. The loop in question only generates comparison logic for mutable columns inside the _changes() function. Junction tables only support INSERT and DELETE (you cannot UPDATE a
  row when every column is part of the PK), and those operations are captured by triggers that are created independently of this loop. History for junction tables works correctly after this fix.